### PR TITLE
fixed delete tests for residence-router 46 tests passing

### DIFF
--- a/lib/error-middleware.js
+++ b/lib/error-middleware.js
@@ -6,6 +6,7 @@ const debug = require('debug')('abba:error-middleware');
 
 module.exports = function(err, req, res, next){
   debug('error middleware');
+  console.error(err.message);
 
   if (err.status){
     res.status(err.status).send(err.name);

--- a/route/residence-router.js
+++ b/route/residence-router.js
@@ -13,46 +13,41 @@ const bearerAuth = require('../lib/bearer-auth-middleware.js');
 
 const residenceRouter = module.exports = Router();
 
-residenceRouter.post('/api/profile/:profileID/residence', bearerAuth, jsonParser, function(req, res, next) {
+residenceRouter.post('/api/residence', bearerAuth, jsonParser, function(req, res, next) {
   debug('POST /api/residence');
-  if(!req.body) return next(createError(400, 'no body'));
-  Profile.findById(req.params.profileID)
-  .catch(err => Promise.reject(createError(404, err.message)))
-  .then(() => {
-    let residence = req.body;
-    residence.profileID = req.params.profileID;
-    residence.userID = req.user._id;
-    return new Residence(residence).save()
-    .then(result => res.json(result));
-  })
+  if(!req.body) return Promise.reject(createError(400, 'no body'));
+  let residence = req.body;
+  residence.userID = req.user._id;
+  return new Residence(residence).save()
+  .then(result => res.json(result))
   .catch(next);
 });
 
-residenceRouter.get('/api/profile/:profileID/residence/:resID', bearerAuth, function(req, res, next){
+residenceRouter.get('/api/residence/:resID', bearerAuth, function(req, res, next){
   debug('GET /api/residence/:resID');
 
   Residence.findById(req.params.resID)
   .catch(err => Promise.reject(createError(400, err.message)))
   .then(residence => {
     if (residence.userID.toString() !== req.user._id.toString())
-      return next(createError(401, 'invalid userID'));
+      return Promise.reject(createError(401, 'invalid userID'));
     res.json(residence);
   })
   .catch(next);
 });
 
-// residenceRouter.delete('/api/profile/:profileID/residence/:resID', bearerAuth, function(req, res, next) {
-//   debug('DELETE /api/residence/:resID');
-//
-//   Residence.findById(req.params.id)
-//   .catch(err => Promise.reject(createError(400, err.message)))
-//   .then(residence => {
-//     if (residence.userID.toString() !== req.user._id.toString())
-//       return next(createError(401, 'invalid userID'));
-//     let oldResidence = residence;
-//     return oldResidence;
-//   });
-//   Residence.remove(oldResidence)
-//   .then(() => res.sendStatus(204))
-//   .catch(err => next(createError(404, err.message)));
-// });
+residenceRouter.delete('/api/residence/:resID', bearerAuth, function(req, res, next) {
+  debug('DELETE /api/residence/:resID!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+
+  Residence.findById(req.params.resID)
+  .then(residence => {
+    if (residence.userID.toString() !== req.user._id.toString())
+      return Promise.reject(createError(401, 'invalid userID'));
+    return Residence.findByIdAndRemove(residence._id);
+  })
+  .catch(err => {
+    return err.status ? Promise.reject(err) : Promise.reject(createError(404, err.message));
+  })
+  .then(() => res.status(204).send())
+  .catch(next);
+});

--- a/standups.md
+++ b/standups.md
@@ -31,3 +31,28 @@ BUGS (5)
 -
 
 Broader To-Dos
+
+Standup - Morning Tuesday October 11th
+
+Accomplished yesterday
+- Logan: wrote residence tests, debugging, 90% done
+- Sarah: worked with logan on above
+- Adam: 60-70% done on photo routing, photo middleware. Finished bedroom mock. Merged everything, debugged, merge conflicts, got all tests passing, added all routes to server.js
+
+Today
+Logan and Sarah
+- 50% CRUD on estimate-router
+- 100% done with residence tests
+
+Adam
+- Finish all photo routes and tests
+- General cleanup and refactor
+- More tests out of existing routes
+- General application tests
+
+Current status
+- All mocks working
+- at least one CRUD on all routes
+
+TODO:
+-

--- a/test/residence-router-test.js
+++ b/test/residence-router-test.js
@@ -33,12 +33,12 @@ describe('testing residence routes', function() {
   before(done => serverControl.serverUp(server, done));
   after(done => serverControl.serverDown(server, done));
   afterEach(done => cleanUpDatabase(done));
-  describe('testing POST /api/profile/:profileid/residence', function() {
+  describe('testing POST /api/residence', function() {
     describe('with valid body', function() {
       before(done => profileMock.call(this, done));
 
       it('should return a residence', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send(exampleResidenceData)
         .end((err, res) => {
@@ -53,7 +53,7 @@ describe('testing residence routes', function() {
       before(done => profileMock.call(this, done));
 
       it('should return a 400 bad request', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send('nope')
         .set('Character-Type', 'application/json')
@@ -68,7 +68,7 @@ describe('testing residence routes', function() {
       before(done => profileMock.call(this, done));
 
       it('should return a 400 bad request', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .send()
         .set('Character-Type', 'application/json')
         .set({Authorization: `Bearer ${this.tempToken}`})
@@ -83,7 +83,7 @@ describe('testing residence routes', function() {
       before(done => residenceMock.call(this, done));
 
       it('should return a 409 error', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send({
           dateBuilt: this.tempResidence.dateBuilt,
@@ -107,7 +107,7 @@ describe('testing residence routes', function() {
       before(done => residenceMock.call(this, done));
 
       it ('should return a 400 error', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send({
           dateBuilt: this.tempResidence.dateBuilt,
@@ -129,7 +129,7 @@ describe('testing residence routes', function() {
       before(done => residenceMock.call(this, done));
 
       it ('should return a 400 error', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send({
           dateBuilt: this.tempResidence.dateBuilt,
@@ -151,7 +151,7 @@ describe('testing residence routes', function() {
       before(done => residenceMock.call(this, done));
 
       it ('should return a 400 error', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send({
           dateBuilt: this.tempResidence.dateBuilt,
@@ -173,7 +173,7 @@ describe('testing residence routes', function() {
       before(done => residenceMock.call(this, done));
 
       it ('should return a 400 error', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send({
           dateBuilt: this.tempResidence.dateBuilt,
@@ -195,7 +195,7 @@ describe('testing residence routes', function() {
       before(done => residenceMock.call(this, done));
 
       it ('should return a 400 error', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send({
           dateBuilt: this.tempResidence.dateBuilt,
@@ -217,7 +217,7 @@ describe('testing residence routes', function() {
       before(done => residenceMock.call(this, done));
 
       it ('should return a 400 error', (done) => {
-        request.post(`${url}/api/profile/${this.tempProfile._id}/residence`)
+        request.post(`${url}/api/residence`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .send({
           dateBuilt: this.tempResidence.dateBuilt,
@@ -236,12 +236,12 @@ describe('testing residence routes', function() {
     }); //end of with no sqft
   }); //end of POST tests
 
-  describe('testing GET /api/profile/:id/residence/:id', function() {
+  describe('testing GET /api/:id/residence/:id', function() {
     //with valid password and auth?
     describe('with valid ID', function() {
       before(done => residenceMock.call(this, done));
       it('should return a residenceID', (done) => {
-        request.get(`${url}/api/profile/${this.tempProfile._id}/residence/${this.tempResidence._id}`)
+        request.get(`${url}/api/residence/${this.tempResidence._id}`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .end((err, res) => {
           if (err) return done(err);
@@ -263,7 +263,7 @@ describe('testing residence routes', function() {
     describe('with an invalid residenceID', function() {
       before(done => residenceMock.call(this, done));
       it('should return a 400 not found', (done) => {
-        request.get(`${url}/api/profile/${this.tempProfile._id}/residence/:wrongid`)
+        request.get(`${url}/api/residence/:wrongid`)
         .set({Authorization: `Bearer ${this.tempToken}`})
         .end((err, res) => {
           //may be a false positive. Error handling in residence get router sends 400 error if anything goes wrong with Residence.findById
@@ -276,7 +276,7 @@ describe('testing residence routes', function() {
     describe('with valid token and id', function(){
       before(done => residenceMock.call(this, done));
       it('should return a residence', done => {
-        request.get(`${url}/api/profile/${this.tempProfile._id}/residence/${this.tempResidence._id}`)
+        request.get(`${url}/api/residence/${this.tempResidence._id}`)
         .set({
           Authorization: `Bearer ${this.tempToken}`,
         })
@@ -302,7 +302,7 @@ describe('testing residence routes', function() {
     describe('with invalid token', function(){
       before(done => residenceMock.call(this, done));
       it('should return a 401 with bad token', done => {
-        request.get(`${url}/api/profile/${this.tempProfile._id}/residence/${this.tempResidence._id}`)
+        request.get(`${url}/api/residence/${this.tempResidence._id}`)
         .set({
           Authorization: 'Bearer ',
         })
@@ -317,7 +317,7 @@ describe('testing residence routes', function() {
     describe('with invalid Bearer auth', function(){
       before(done => residenceMock.call(this, done));
       it('should return a 401 error with invalid Bearer', done => {
-        request.get(`${url}/api/profile/${this.tempProfile._id}/residence/${this.tempResidence._id}`)
+        request.get(`${url}/api/residence/${this.tempResidence._id}`)
         .set({ Authorization: 'bad request' })
         .end((err, res) => {
           expect(res.status).to.equal(401);
@@ -330,7 +330,7 @@ describe('testing residence routes', function() {
     describe('with no Authorization header', function(){
       before(done => residenceMock.call(this, done));
       it('should return a 401 error with no Authorization header', done => {
-        request.get(`${url}/api/profile/${this.tempProfile._id}/residence/${this.tempResidence._id}`)
+        request.get(`${url}/api/residence/${this.tempResidence._id}`)
         .end((err, res) => {
           expect(res.status).to.equal(401);
           done();
@@ -341,7 +341,7 @@ describe('testing residence routes', function() {
     describe('with invalid id', function(){
       before(done => residenceMock.call(this, done));
       it('should return a 400 error with invalid ID', done => {
-        request.get(`${url}/api/profile/${this.tempProfile._id}/residence/invalid`)
+        request.get(`${url}/api/residence/invalid`)
         .set({
           Authorization: `Bearer ${this.tempToken}`,
         })
@@ -355,83 +355,71 @@ describe('testing residence routes', function() {
     });
   });
 
-  // describe('testing DELETE /api/profile/:id/residence/:id', function(){
-  //
-  //   describe('with valid token and ids', function(){
-  //     before(done => residenceMock.call(this, done));
-  //
-  //     it('should respond with status 204', done => {
-  //       request.delete(`${url}/api/profile/${this.tempProfile._id}/residence/${this.tempResidence._id}`)
-  //       .set({Authorization: `Bearer ${this.tempToken}`})
-  //       .end((err, res) => {
-  //         if (err) return done(err);
-  //         expect(res.status).to.equal(204);
-  //         done();
-  //       });
-  //     });
-  //   });
-  //   describe('with invalid token', function(){
-  //     before(done => residenceMock.call(this, done));
-  //     it('should respond with status 401', done => {
-  //       request.delete(`${url}/api/profile/${this.tempProfile._id}/pic/${this.tempResidence._id}`)
-  //       .set({Authorization: `Bearer ${this.tempToken}bad`})
-  //       .end((err, res) => {
-  //         expect(res.status).to.equal(401);
-  //         expect(res.text).to.equal('UnauthorizedError');
-  //         done();
-  //       });
-  //     });
-  //   });
-  //
-  //   describe('no auth header', function(){
-  //     before(done => residenceMock.call(this, done));
-  //     it('should respond with status 400', done => {
-  //       request.delete(`${url}/api/profile/${this.tempProfile._id}/pic/${this.tempResidence._id}`)
-  //       .end((err, res) => {
-  //         expect(res.status).to.equal(400);
-  //         expect(res.text).to.equal('BadRequestError');
-  //         done();
-  //       });
-  //     });
-  //   });
-  //
-  //   describe('with no bearer auth', function(){
-  //     before(done => residenceMock.call(this, done));
-  //     it('should respond with status 400', done => {
-  //       request.delete(`${url}/api/profile/${this.tempProfile._id}/pic/${this.tempResidence._id}`)
-  //       .set({Authorization: 'lul this is bad}'})
-  //       .end((err, res) => {
-  //         expect(res.status).to.equal(400);
-  //         expect(res.text).to.equal('BadRequestError');
-  //         done();
-  //       });
-  //     });
-  //   });
-  //
-  //   describe('with invalid profileID', function(){
-  //     before(done => residenceMock.call(this, done));
-  //     it('should respond with status 400', done => {
-  //       request.delete(`${url}/api/profile/${this.tempProfile._id}bad/pic/${this.tempResidence._id}`)
-  //       .set({Authorization: `Bearer ${this.tempToken}`})
-  //       .end((err, res) => {
-  //         expect(res.status).to.equal(400);
-  //         expect(res.text).to.equal('BadRequestError');
-  //         done();
-  //       });
-  //     });
-  //   });
-  //
-  //   describe('with invalid residenceID', function(){
-  //     before(done => residenceMock.call(this, done));
-  //     it('should respond with status 404', done => {
-  //       request.delete(`${url}/api/profile/${this.tempProfile._id}/pic/${this.tempResidence._id}bad`)
-  //       .set({Authorization: `Bearer ${this.tempToken}`})
-  //       .end((err, res) => {
-  //         expect(res.status).to.equal(404);
-  //         expect(res.text).to.equal('NotFoundError');
-  //         done();
-  //       });
-  //     });
-  //   });
-  // });
+  describe('testing DELETE /api/residence/:resID', function(){
+
+    describe('with valid token and ids', function(){
+      before(done => residenceMock.call(this, done));
+
+      it('should respond with status 204', done => {
+        request.delete(`${url}/api/residence/${this.tempResidence._id}`)
+        .set({Authorization: `Bearer ${this.tempToken}`})
+        .end((err, res) => {
+          console.log('getting back to test file!');
+          if (err) return done(err);
+          expect(res.status).to.equal(204);
+          done();
+        });
+      });
+    });
+    describe('with invalid token', function(){
+      before(done => residenceMock.call(this, done));
+      it('should respond with status 401', done => {
+        request.delete(`${url}/api/residence/${this.tempResidence._id}`)
+        .set({Authorization: `Bearer ${this.tempToken}bad`})
+        .end((err, res) => {
+          expect(res.status).to.equal(401);
+          expect(res.text).to.equal('UnauthorizedError');
+          done();
+        });
+      });
+    });
+
+    describe('no auth header', function(){
+      before(done => residenceMock.call(this, done));
+      it('should respond with status 401', done => {
+        request.delete(`${url}/api/residence/${this.tempResidence._id}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(401);
+          expect(res.text).to.equal('UnauthorizedError');
+          done();
+        });
+      });
+    });
+
+    describe('with invalid bearer auth', function(){
+      before(done => residenceMock.call(this, done));
+      it('should respond with status 401', done => {
+        request.delete(`${url}/api/residence/${this.tempResidence._id}`)
+        .set({Authorization: 'lul this is bad}'})
+        .end((err, res) => {
+          expect(res.status).to.equal(401);
+          expect(res.text).to.equal('UnauthorizedError');
+          done();
+        });
+      });
+    });
+
+    describe('with invalid residenceID', function(){
+      before(done => residenceMock.call(this, done));
+      it('should respond with status 404', done => {
+        request.delete(`${url}/api/residence/badID`)
+        .set({Authorization: `Bearer ${this.tempToken}`})
+        .end((err, res) => {
+          expect(res.status).to.equal(404);
+          expect(res.text).to.equal('NotFoundError');
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Refactored residencerouter.delete
- Refactored tests and residenceRouter to exclude profileID
- All residence-router tests passing
